### PR TITLE
Fix unhashable type happened when trying to get subset of metric keys

### DIFF
--- a/tcollector.py
+++ b/tcollector.py
@@ -703,7 +703,8 @@ class SenderThread(threading.Thread):
         metric_entry["tags"] = dict(self.tags).copy()
         if len(metric_tags) + len(metric_entry["tags"]) > self.maxtags:
           metric_tags_orig = set(metric_tags)
-          subset_metric_keys = frozenset(metric_tags[:len(metric_tags[:self.maxtags-len(metric_entry["tags"])])])
+          metric_tags_keys = metric_tags.keys()
+          subset_metric_keys = frozenset(metric_tags_keys[:len(metric_tags_keys[:self.maxtags-len(metric_entry["tags"])])])
           metric_tags = dict((k, v) for k, v in metric_tags.iteritems() if k in subset_metric_keys)
           LOG.error("Exceeding maximum permitted metric tags - removing %s for metric %s",
                     str(metric_tags_orig - set(metric_tags)), metric)

--- a/tcollector.py
+++ b/tcollector.py
@@ -725,6 +725,10 @@ class SenderThread(threading.Thread):
             for line in self.sendq:
                 # always just put tags and defaults into tags because elk can take it all
                 metric_data = self.parse_metric(line, length_check=False)
+                for k,v in metric_data["tags"].iteritems():
+                    if k not in self.tags.keys()
+                        metric_data[k] = v
+                metric_data.pop('tags', None)
                 LOG_METRICS.debug(json.dumps(metric_data))
 
                 line = "put %s" % self.add_tags_to_line(line)


### PR DESCRIPTION
This is an _hidden_ upstream bug, which only happens when total of metric tags sent exceed the specified `maxtags`, which equals 8 at the moment.

*Before fix*:

```
Traceback (most recent call last):
  File "/opt/nsone-tcollector/nsone-tcollector/tcollector.py", line 519, in run
    self.send_data()
  File "/opt/nsone-tcollector/nsone-tcollector/tcollector.py", line 725, in send_data
    for line in self.sendq:
  File "/opt/nsone-tcollector/nsone-tcollector/tcollector.py", line 706, in parse_metric
    metric_tags_keys = metric_tags.keys()
TypeError: unhashable type
```

*After fix* (this error line is 100% expected by logic, since the code try to exclude some tags to ensure total tags count less than or equals `self.maxtags`):

```
2017-09-18 10:22:47,138 tcollector[138946] ERROR: Exceeding maximum permitted metric tags - removing set(['instid']) for metric mnotifyd.event
```

@nsone/devops, @linearb : One question here: is is there any reason to keep options.maxtags == 8? Can we increase this number? I also see in `core01.sfo02` which is _experimenting_ `dnsdatad` also emitted more metric tags now.